### PR TITLE
Document two additional interval annotation API fields

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -871,6 +871,8 @@ curl -G "http://portaldev.sph.umich.edu/api_internal_dev/v1/annotation/intervals
 Field | Description
 ----- | -----------
 id | Interval dataset identifier
+state_id | A (numeric) state identifier for this annotation, such as determined by ChromHMM. (if applicable)  
+state_name | A human-readable state name that generally corresponds to an entry in state_id. (if applicable)
 public_id | Public/other database ID for this interval (if applicable)
 chromosome | Chromosome
 start | Start of interval (in bp)


### PR DESCRIPTION
# Purpose
Expand documentation for `/annotation/intervals/results/` endpoint to cover missing fields.

# Followup
There may be other fields to document in the future. (capturing discussion before I forget)

The `annotations` field is mentioned in the docs (and [code](https://github.com/abought/locuszoom-api/blob/07dd95f2454c8b564f80df7dc1ebf3f16f4ff875/portalapi/controllers/routes.py#L376)), but not in any of the sample responses I can find for this endpoint. 

Because it is a nested object, it might be helpful to include a sample with the expected key:value entries.